### PR TITLE
Generalizing to convert any HTML (incl. email!) to markdown

### DIFF
--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -258,7 +258,7 @@ class HTML_To_Markdown
                 break;
             case "div":
                 if ($this->options['strip_tags']) {
-                    $markdown = PHP_EOL . PHP_EOL;
+                    $markdown = $value . PHP_EOL . PHP_EOL;
                     break;    
                 }
             default:

--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -239,7 +239,7 @@ class HTML_To_Markdown
                 break;
             case "ol":
             case "ul":
-                $markdown = $value . PHP_EOL;
+                $markdown = PHP_EOL . PHP_EOL . $value . PHP_EOL;
                 break;
             case "li":
                 $markdown = $this->convert_list($node);

--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -258,7 +258,7 @@ class HTML_To_Markdown
                 break;
             case "div":
                 if ($this->options['strip_tags']) {
-                    $markdown = $value . PHP_EOL . PHP_EOL;
+                    $markdown = PHP_EOL . PHP_EOL . $value;
                     break;    
                 }
             default:

--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -31,6 +31,7 @@ class HTML_To_Markdown
         'strip_tags'      => false, // Set to true to strip tags that don't have markdown equivalents. N.B. Strips tags, not their content. Useful to clean MS Word HTML output.
         'bold_style'      => '**', // Set to '__' if you prefer the underlined style
         'italic_style'    => '*', // Set to '_' if you prefer the underlined style
+        'remove_nodes'    => '', // space-separated list of dom nodes that should be removed. example: "meta style script"
     );
 
 
@@ -154,6 +155,17 @@ class HTML_To_Markdown
      */
     private function get_markdown()
     {
+        // First remove all nodes that should be removed.
+        if ($this->options['remove_nodes'] <> '') {
+          $tags = split(' ', $this->options['remove_nodes']);
+          foreach ($tags as $tag) {
+            $removeNodes = $this->document->getElementsByTagName($tag);
+            for ($i = 0; $i < $removeNodes->length; $i++) {
+              $removeNodes->item(0)->parentNode->removeChild($removeNodes->item(0));
+            }
+          }
+        }
+        
         // Use the body tag as our root element
         $body = $this->document->getElementsByTagName("body")->item(0);
 
@@ -252,6 +264,7 @@ class HTML_To_Markdown
                 break;
             case "#text":
                 $markdown = preg_replace('~\s+~', ' ', $value);
+                $markdown = preg_replace('~^#~', '\\\\#', $markdown);
                 break;
             case "#comment":
                 $markdown = '';

--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -256,6 +256,11 @@ class HTML_To_Markdown
             case "#comment":
                 $markdown = '';
                 break;
+            case "div":
+                if ($this->options['strip_tags']) {
+                    $markdown = PHP_EOL . PHP_EOL;
+                    break;    
+                }
             default:
                 // If strip_tags is false (the default), preserve tags that don't have Markdown equivalents,
                 // such as <span> and #text nodes on their own. C14N() canonicalizes the node to a string.

--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -383,7 +383,7 @@ class HTML_To_Markdown
     {
         $href = $node->getAttribute('href');
         $title = $node->getAttribute('title');
-        $text = $node->nodeValue;
+        $text = trim(preg_replace('/\s+/', ' ', $node->nodeValue));
 
         if ($title != "") {
             $markdown = '[' . $text . '](' . $href . ' "' . $title . '")';


### PR DESCRIPTION
When "strip_tags" option is on, divs vanish. However, they often need a line feed.

I chose to add a paragraph break, but a line break would be just as ok for me.

Thanks for the great code!