### PR TITLE
<a> tags with identical href and inner text are now rendered using angular bracket syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased][unreleased]
+### Changed
+ - `<a>` tags with identical href and inner text are now rendered using angular bracket syntax (#31)
 
 ## [2.2.2]
 ### Added

--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -384,6 +384,8 @@ class HTML_To_Markdown
 
         if ($title != "") {
             $markdown = '[' . $text . '](' . $href . ' "' . $title . '")';
+        } elseif ($href === $text) {
+            $markdown = '<' . $href . '>';
         } else {
             $markdown = '[' . $text . '](' . $href . ')';
         }

--- a/tests/HTML_To_MarkdownTest.php
+++ b/tests/HTML_To_MarkdownTest.php
@@ -67,6 +67,7 @@ class HTML_To_MarkdownTest extends PHPUnit_Framework_TestCase
 
     public function test_anchor()
     {
+        $this->html_gives_markdown('<a href="http://modernnerd.net">http://modernnerd.net</a>', '<http://modernnerd.net>');
         $this->html_gives_markdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title")');
         $this->html_gives_markdown('<a href="http://modernnerd.net" title="Title">Modern Nerd</a> <a href="http://modernnerd.net" title="Title">Modern Nerd</a>', '[Modern Nerd](http://modernnerd.net "Title") [Modern Nerd](http://modernnerd.net "Title")');
         $this->html_gives_markdown('<a href="http://modernnerd.net/" title="Title"><img src="/path/img.jpg" alt="alt text" title="Title"/></a>', '[![alt text](/path/img.jpg "Title")](http://modernnerd.net/ "Title")');


### PR DESCRIPTION
Fixed #31

All feedback is welcome. Thanks.