### PR TITLE
Treat <div> as a block level element.

### DIFF
--- a/HTML_To_Markdown.php
+++ b/HTML_To_Markdown.php
@@ -630,6 +630,7 @@ class HTML_To_Markdown
             case "blockquote":
             case "body":
             case "code":
+            case "div":
             case "h1":
             case "h2":
             case "h3":

--- a/tests/HTML_To_MarkdownTest.php
+++ b/tests/HTML_To_MarkdownTest.php
@@ -144,6 +144,7 @@ class HTML_To_MarkdownTest extends PHPUnit_Framework_TestCase
     {
         $this->html_gives_markdown('<div>Hello</div><div>World</div>', '<div>Hello</div><div>World</div>');
         $this->html_gives_markdown('<div>Hello</div><div>World</div>', "Hello\n\nWorld", array('strip_tags' => true));
+        $this->html_gives_markdown("<div>Hello</div>\n<div>World</div>", "Hello\n\nWorld", array('strip_tags' => true));
         $this->html_gives_markdown('<p>Paragraph</p><div>Hello</div><div>World</div>', "Paragraph\n\nHello\n\nWorld", array('strip_tags' => true));
     }
 


### PR DESCRIPTION
Prevents extra spaces between back to back div's.

Previously, with `strip_tags` `true`, the HTML:

```
<div>Hello</div>
<div>World</div>
```

Would render to:

```
Hello

 World
```

Notice the extra space in front of "World". This fixes the extra space.
